### PR TITLE
Add object-fit polyfill and apply it to hero header

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5312,6 +5312,11 @@
         "make-iterator": "^1.0.0"
       }
     },
+    "objectFitPolyfill": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/objectFitPolyfill/-/objectFitPolyfill-2.3.0.tgz",
+      "integrity": "sha512-VgF98xGs2upBxO6a4FKGEEip5kXQCYpIwrKSDQ6oyFvPAmTrm6nPD/Y/IetoHx62HE6N82hWvc7Tc0evEBkoyA=="
+    },
     "on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "gulp-rename": "^2.0.0",
     "gulp-sass": "^4.1.0",
     "gulp-sass-glob": "^1.1.0",
+    "objectFitPolyfill": "^2.3.0",
     "webpack": "^4.44.1",
     "webpack-stream": "^6.1.0"
   }

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,3 +1,6 @@
+//object-fitポリフィル
+import objectFitPolyfill from 'objectFitPolyfill';
+
 import setHeroHeaderHeight from './features/setHeroHeaderHeight';
 
 window.addEventListener( 'load', () => {

--- a/template_parts/hero-header.php
+++ b/template_parts/hero-header.php
@@ -1,7 +1,7 @@
 <div id="heroHeader" class="hero-header">
 
   <div class="hero-header__bg">
-    <img class="hero-header__bg-img" src="<?php echo esc_url( get_template_directory_uri() . '/assets/images/header.jpg' ); ?>" alt="">
+    <img class="hero-header__bg-img" src="<?php echo esc_url( get_template_directory_uri() . '/assets/images/header.jpg' ); ?>" data-object-fit="cover">
 
     <svg class="hero-header__bg-grid-line-svg" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 1000 1000" height="1000" width="1000">
       <path d="M 200,0 V 1000"></path>


### PR DESCRIPTION
## object-fitポリフィルを追加し、それをヒーローヘッダーに適用。

IE11はCSSの'object-fit'プロパティが対応しておらず、ヒーローヘッダーの背景画像の伸びが発生したため、上記やり方で修正。

### 使用パッケージ

[object-fit-polyfill](https://github.com/constancecchen/object-fit-polyfill) 