### PR TITLE
Change the max number of columns in the post list from 4 to 3

### DIFF
--- a/src/sass/blocks/_post-list.scss
+++ b/src/sass/blocks/_post-list.scss
@@ -1,18 +1,15 @@
 .post-list {
   &__posts {
     &-sizer {
+      
       width: 100%;
-
+    
       @include media-query(sph) {
         width: 50%;
       }
-
-      @include media-query(tc) {
-        width: 33.3333%;
-      }
-
+    
       @include media-query(pc) {
-        width: 25%;
+        width: 33.3333%;
       }
     }
   }

--- a/src/sass/blocks/_post.scss
+++ b/src/sass/blocks/_post.scss
@@ -5,12 +5,8 @@
     width: 50%;
   }
 
-  @include media-query(tc) {
-    width: 33.3333%;
-  }
-
   @include media-query(pc) {
-    width: 25%;
+    width: 33.3333%;
   }
 
   &__link {


### PR DESCRIPTION
投稿リストの列数が今のままだと、環境によっては、投稿が細長くなり、読みづらくなる可能性があるため、
投稿リストの列の最大数を4から3に変更し、投稿一つ一つに余裕を持たせ、読みやすくする。