### PR TITLE
Change the value of the SASS variable 'gray' from '#F8F8F8' to '#EEE'

### DIFF
--- a/src/sass/_config.scss
+++ b/src/sass/_config.scss
@@ -1,6 +1,6 @@
 //カラー
 $black: #333;
-$gray: #F8F8F8;
+$gray: #EEE;
 
 //フォント
 @font-face {


### PR DESCRIPTION
現在のSASS変数'gray'の値だと、背景の白色とのコントラストが小さく、見づらいので、
変数'gray'の値を'#F8F8F8'から'#EEE'に変更し、見やすくする。