### PR TITLE
Add a feature to display posts the previous page based on the 'load_count' URL parameter

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1,5 +1,6 @@
 <?php
-locate_template('./functions/init.php', true);    //テーマの初期設定
-locate_template('./functions/nav-menu.php', true);    //ナビゲーションメニューの設定
-locate_template('./functions/widgets.php', true); //ウィジェットの設定
-locate_template('./functions/scripts.php', true); //外部css, jsファイルの読み込み
+locate_template('./functions/init.php', true);      //テーマの初期設定
+locate_template('./functions/content.php', true);   //コンテンツ部分の関数など
+locate_template('./functions/nav-menu.php', true);  //ナビゲーションメニューの設定
+locate_template('./functions/widgets.php', true);   //ウィジェットの設定
+locate_template('./functions/scripts.php', true);   //外部css, jsファイルの読み込み

--- a/functions/content.php
+++ b/functions/content.php
@@ -1,0 +1,118 @@
+<?php
+//コンテンツ部分の関数
+
+//メイクエリの制御
+add_action( 'pre_get_posts', function($query) {
+  if ( is_admin() || !$query->is_main_query() ) return;
+
+  //投稿の先頭固定表示設定を反映させない
+  $query->set( 'ignore_sticky_posts', true );
+} );
+
+//投稿リストの投稿アイテムを出力
+//※引数「$post_id」を指定しない場合、現在の投稿を取得。
+function the_post_list_item( $post_id = null ) {
+  //投稿オブジェクトを取得
+  $post_obj = get_post( $post_id );
+  ?>
+
+  <article <?php post_class(); ?>>
+          
+    <a class="post__link" href="<?php the_permalink( $post_obj ); ?>">
+    
+      <?php if ( has_post_thumbnail( $post_obj->ID ) ) : ?>
+        <figure class="post__featured-media">
+          <?php echo get_the_post_thumbnail( $post_obj->ID, 'post-thumbnail', [ 'data-object-fit' => 'cover' ] ); ?>
+        </figure><!--post__featured-media-->
+      <?php endif; ?>
+
+      <div class="post__content">
+
+        <?php $post_title = esc_html( get_the_title( $post_obj ) );
+        if ( $post_title !== '' ) : ?>
+          <div class="post__content-header">
+            <h2 class="post__content-title">
+              <?php echo $post_title; ?>
+            </h2>
+          </div><!--post__content-header-->
+        <?php endif; ?>
+        
+        <div class="post__content-footer">
+
+          <?php $categories = get_the_category( $post_obj->ID );
+          if ( $categories ) : ?>
+            <div class="post__content-taxonomy">
+              <span class="post__content-taxonomy-icon">
+                <svg class="post__content-taxonomy-icon-svg" xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24">
+                  <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"></path>
+                </svg>
+              </span>
+
+              <ul class="post__content-taxonomy-list">
+                <?php foreach ( $categories as $category ) : ?>
+                  <li class="post__content-taxonomy-list-item"><?php echo esc_html( $category->name ); ?></li>
+                <?php endforeach; ?>
+              </ul>
+
+            </div><!--.post__content-taxonomy-->
+          <?php endif; ?>
+
+          <?php $tags = get_the_tags( $post_obj->ID );
+          if ( $tags ) : ?>
+            <div class="post__content-taxonomy">
+              <span class="post__content-taxonomy-icon">
+                <svg class="post__content-taxonomy-icon-svg" xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 24 24" >
+                  <path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z"></path>
+                  <line x1="7" y1="7" x2="7.01" y2="7"></line>
+                </svg>
+              </span>
+
+              <ul class="post__content-taxonomy-list">
+                <?php foreach ( $tags as $tag ) : ?>
+                  <li class="post__content-taxonomy-list-item"><?php echo esc_html( $tag->name ); ?></li>
+                <?php endforeach; ?>
+              </ul>
+
+            </div><!--.post__content-taxonomy-->
+          <?php endif; ?>
+        
+        </div><!--post_content-footer-->
+      
+      </div><!--.post__content-->
+
+    </a>
+
+  </article><!--.post-->
+
+  <?php
+}
+
+//'load_count'URLパラメータを元に、前のページの投稿リストの投稿アイテムを出力
+function the_prev_post_list_items() {
+  global $wp_query;
+
+  if ( !isset( $_GET['load_count'] ) ) return;
+
+  $load_count = (int) wp_unslash( $_GET['load_count'] );
+  if ( $load_count <= 0 ) return;
+
+  $current_page = (int) get_query_var('paged');
+  if ( $current_page <= 0 ) $current_page = 1;
+
+  $load_page = $current_page - $load_count;
+  if ( $load_page <= 0 ) return;
+
+  $args = $wp_query->query_vars;
+  $args['paged'] = $load_page;
+  $args['posts_per_page'] = $load_count * (int) get_option('posts_per_page');
+
+  $query = new WP_Query( $args );
+
+  if ( $query->have_posts() ) {
+    while ( $query->have_posts() ) {
+      $query->the_post();
+      the_post_list_item( $query->post->ID );
+    }
+    wp_reset_postdata();
+  }
+}

--- a/src/js/features/postList.js
+++ b/src/js/features/postList.js
@@ -17,15 +17,36 @@ export default () => {
   } );
 
   //show-more-button要素にクリック時、投稿追加表示の機能を設定
-  InfiniteScroll.imagesLoaded = ImagesLoaded;
-  const infiniteScroll = new InfiniteScroll( container, {
-    outlayer: masonry,
-    path: '.post-list__navigation-next-page-link > a',
-    append: '.post',
-    button: '.post-list__show-more-button',
-    scrollThreshold: false,
-    hideNav: '.post-list__navigation',
-    status: '.post-list__page-load-status',
-  } );
+  const nextPageLinkElemSelector = '.post-list__navigation-next-page-link > a';
+  const showMoreButtonElemSelector = '.post-list__show-more-button';
+  const postListStatusElemSelector = '.post-list__page-load-status';
+  const postListNavElemSelector = '.post-list__navigation';
+  
+  const nextPageLinkElem = document.querySelector(nextPageLinkElemSelector);
+  if ( nextPageLinkElem !== null ) {
+    InfiniteScroll.imagesLoaded = ImagesLoaded;
+
+    const nextPageURL = new URL( nextPageLinkElem.href );
+    nextPageURL.searchParams.delete('load_count');
+    nextPageLinkElem.href = nextPageURL.href;
+    
+    const infiniteScroll = new InfiniteScroll( container, {
+      outlayer: masonry,
+      path: nextPageLinkElemSelector,
+      append: '.post',
+      button: showMoreButtonElemSelector,
+      scrollThreshold: false,
+      status: postListStatusElemSelector,
+      hideNav: postListNavElemSelector,
+      history: false,
+    } );
+
+  } else {
+    document.querySelector(showMoreButtonElemSelector).style.display = 'none';
+    document.querySelector( postListStatusElemSelector ).style.display = 'block';
+    document.querySelector( postListStatusElemSelector + ' > .infinite-scroll-request' ).style.display = 'none';
+    document.querySelector( postListStatusElemSelector + ' > .infinite-scroll-error' ).style.display = 'none';
+    document.querySelector( postListNavElemSelector ).style.display = 'none';
+  }
 
 }

--- a/src/js/features/postList.js
+++ b/src/js/features/postList.js
@@ -41,6 +41,14 @@ export default () => {
       history: false,
     } );
 
+    let url = new URL( location.href );
+    const startLoadCount = Number( url.searchParams.get('load_count') );
+    infiniteScroll.on( 'load', function( document, path ) {
+      url = new URL( path );
+      url.searchParams.set( 'load_count', startLoadCount + this.loadCount );
+      history.replaceState(null, '', url);
+    } );
+
   } else {
     document.querySelector(showMoreButtonElemSelector).style.display = 'none';
     document.querySelector( postListStatusElemSelector ).style.display = 'block';

--- a/template_parts/post-list.php
+++ b/template_parts/post-list.php
@@ -6,72 +6,11 @@
 
         <div class="post-list__posts-sizer"></div>
 
+        <?php the_prev_post_list_items(); ?>
+
         <?php while ( have_posts() ) : the_post(); ?>
           
-          <article <?php post_class(); ?>>
-          
-            <a class="post__link" href="<?php the_permalink(); ?>">
-            
-              <?php if ( has_post_thumbnail() ) : ?>
-                <figure class="post__featured-media">
-                  <?php the_post_thumbnail( 'post-thumbnail', [ 'data-object-fit' => 'cover' ] ); ?>
-                </figure><!--post__featured-media-->
-              <?php endif; ?>
-
-              <div class="post__content">
-
-                <?php if ( esc_html( get_the_title() ) !== '' ) : ?>
-                  <div class="post__content-header">
-                    <?php the_title( '<h2 class="post__content-title">', '</h2>' ); ?>
-                  </div><!--post__content-header-->
-                <?php endif; ?>
-                
-                <div class="post__content-footer">
-
-                  <?php $categories = get_the_category();
-                  if ( $categories ) : ?>
-                    <div class="post__content-taxonomy">
-                      <span class="post__content-taxonomy-icon">
-                        <svg class="post__content-taxonomy-icon-svg" xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24">
-                          <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"></path>
-                        </svg>
-                      </span>
-
-                      <ul class="post__content-taxonomy-list">
-                        <?php foreach ( $categories as $category ) : ?>
-                          <li class="post__content-taxonomy-list-item"><?php echo esc_html( $category->name ); ?></li>
-                        <?php endforeach; ?>
-                      </ul>
-
-                    </div><!--.post__content-taxonomy-->
-                  <?php endif; ?>
-
-                  <?php $tags = get_the_tags();
-                  if ( $tags ) : ?>
-                    <div class="post__content-taxonomy">
-                      <span class="post__content-taxonomy-icon">
-                        <svg class="post__content-taxonomy-icon-svg" xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 24 24" >
-                          <path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z"></path>
-                          <line x1="7" y1="7" x2="7.01" y2="7"></line>
-                        </svg>
-                      </span>
-
-                      <ul class="post__content-taxonomy-list">
-                        <?php foreach ( $tags as $tag ) : ?>
-                          <li class="post__content-taxonomy-list-item"><?php echo esc_html( $tag->name ); ?></li>
-                        <?php endforeach; ?>
-                      </ul>
-
-                    </div><!--.post__content-taxonomy-->
-                  <?php endif; ?>
-                
-                </div><!--post_content-footer-->
-              
-              </div><!--.post__content-->
-
-            </a>
-
-          </article><!--.post-->
+          <?php the_post_list_item( $post->ID ); ?>
 
         <?php endwhile; ?>
 


### PR DESCRIPTION
'load_count'URLパラメータを元に、前のページの投稿リストの投稿を表示する機能を追加。

これにより、ページ移管後のブラウザバックでも、投稿リストの状態をページ移管前の状態に復元できるようになるため、ユーザービリティを高めることができる。

## ※注意点

この機能の追加の使用上、WordPressの機能「投稿の先頭固定表示」は無効になります。
