### PR TITLE
Rename the post list item class name from 'post' to 'post-item'

### DIFF
--- a/functions/content.php
+++ b/functions/content.php
@@ -16,73 +16,73 @@ function the_post_list_item( $post_id = null ) {
   $post_obj = get_post( $post_id );
   ?>
 
-  <article <?php post_class(); ?>>
+  <article <?php post_class('post-item'); ?>>
           
-    <a class="post__link" href="<?php the_permalink( $post_obj ); ?>">
+    <a class="post-item__link" href="<?php the_permalink( $post_obj ); ?>">
     
       <?php if ( has_post_thumbnail( $post_obj->ID ) ) : ?>
-        <figure class="post__featured-media">
+        <figure class="post-item__featured-media">
           <?php echo get_the_post_thumbnail( $post_obj->ID, 'post-thumbnail', [ 'data-object-fit' => 'cover' ] ); ?>
-        </figure><!--post__featured-media-->
+        </figure><!--post-item__featured-media-->
       <?php endif; ?>
 
-      <div class="post__content">
+      <div class="post-item__content">
 
         <?php $post_title = esc_html( get_the_title( $post_obj ) );
         if ( $post_title !== '' ) : ?>
-          <div class="post__content-header">
-            <h2 class="post__content-title">
+          <div class="post-item__content-header">
+            <h2 class="post-item__content-title">
               <?php echo $post_title; ?>
             </h2>
-          </div><!--post__content-header-->
+          </div><!--post-item__content-header-->
         <?php endif; ?>
         
-        <div class="post__content-footer">
+        <div class="post-item__content-footer">
 
           <?php $categories = get_the_category( $post_obj->ID );
           if ( $categories ) : ?>
-            <div class="post__content-taxonomy">
-              <span class="post__content-taxonomy-icon">
-                <svg class="post__content-taxonomy-icon-svg" xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24">
+            <div class="post-item__content-taxonomy">
+              <span class="post-item__content-taxonomy-icon">
+                <svg class="post-item__content-taxonomy-icon-svg" xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24">
                   <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"></path>
                 </svg>
               </span>
 
-              <ul class="post__content-taxonomy-list">
+              <ul class="post-item__content-taxonomy-list">
                 <?php foreach ( $categories as $category ) : ?>
-                  <li class="post__content-taxonomy-list-item"><?php echo esc_html( $category->name ); ?></li>
+                  <li class="post-item__content-taxonomy-list-item"><?php echo esc_html( $category->name ); ?></li>
                 <?php endforeach; ?>
               </ul>
 
-            </div><!--.post__content-taxonomy-->
+            </div><!--.post-item__content-taxonomy-->
           <?php endif; ?>
 
           <?php $tags = get_the_tags( $post_obj->ID );
           if ( $tags ) : ?>
-            <div class="post__content-taxonomy">
-              <span class="post__content-taxonomy-icon">
-                <svg class="post__content-taxonomy-icon-svg" xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 24 24" >
+            <div class="post-item__content-taxonomy">
+              <span class="post-item__content-taxonomy-icon">
+                <svg class="post-item__content-taxonomy-icon-svg" xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 24 24" >
                   <path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z"></path>
                   <line x1="7" y1="7" x2="7.01" y2="7"></line>
                 </svg>
               </span>
 
-              <ul class="post__content-taxonomy-list">
+              <ul class="post-item__content-taxonomy-list">
                 <?php foreach ( $tags as $tag ) : ?>
-                  <li class="post__content-taxonomy-list-item"><?php echo esc_html( $tag->name ); ?></li>
+                  <li class="post-item__content-taxonomy-list-item"><?php echo esc_html( $tag->name ); ?></li>
                 <?php endforeach; ?>
               </ul>
 
-            </div><!--.post__content-taxonomy-->
+            </div><!--.post-item__content-taxonomy-->
           <?php endif; ?>
         
-        </div><!--post_content-footer-->
+        </div><!--post-item_content-footer-->
       
-      </div><!--.post__content-->
+      </div><!--.post-item__content-->
 
     </a>
 
-  </article><!--.post-->
+  </article><!--.post-item-->
 
   <?php
 }

--- a/src/js/features/postList.js
+++ b/src/js/features/postList.js
@@ -11,7 +11,7 @@ export default () => {
   const container = postList.querySelector('.post-list__posts');
 
   const masonry = new Masonry( container, {
-    itemSelector: '.post',
+    itemSelector: '.post-item',
     columnWidth: '.post-list__posts-sizer',
     percentPosition: true,
   } );
@@ -33,7 +33,7 @@ export default () => {
     const infiniteScroll = new InfiniteScroll( container, {
       outlayer: masonry,
       path: nextPageLinkElemSelector,
-      append: '.post',
+      append: '.post-item',
       button: showMoreButtonElemSelector,
       scrollThreshold: false,
       status: postListStatusElemSelector,

--- a/src/sass/blocks/_post-item.scss
+++ b/src/sass/blocks/_post-item.scss
@@ -1,4 +1,4 @@
-.post {
+.post-item {
   width: 100%;
 
   @include media-query(sph) {


### PR DESCRIPTION
投稿リストを表示の際、固定ページが含まれていると意図したスタイルが適応されないため、投稿リストアイテムのクラス名を'post'から'post-item'にリネーム。