### PR TITLE
Fix a bug that the display shifts when the ul element and ol element are nested

### DIFF
--- a/src/sass/mixin/_post-content.scss
+++ b/src/sass/mixin/_post-content.scss
@@ -112,11 +112,11 @@
 
   ul:not(.blocks-gallery-grid), ol {
     line-height: 1.8;
-    margin: 3em 0;
+    margin: 3em auto;
     padding-left: 2em;
 
     ul, ol {
-      margin: 0 0 0 1em;
+      margin: 0 0 0 1em !important;
     }
   }
 


### PR DESCRIPTION
ul要素とol要素が入れ子状態になった場合、表示がずれるバグを修正。