### PR TITLE
Hide the sidebar logo when not on the PC

### DIFF
--- a/src/sass/blocks/_sidebar.scss
+++ b/src/sass/blocks/_sidebar.scss
@@ -60,7 +60,7 @@
       padding: 50px 30px;
     }
 
-    & > * + * {
+    & > * + *:not(.menu-all-pages-container) {
       margin-top: 40px;
     }
   }
@@ -71,7 +71,12 @@
   }
 
   &__logo {
-    margin: 0;
+    display: none;
+    margin: 0 0 40px 0;
     text-align: center;
+
+    @include media-query(pc) {
+      display: block;
+    }
   }
 }


### PR DESCRIPTION
画面内にサイトのロゴが複数表示されてしまうため、PC表示以外の時にサイドバーのロゴを非表示にする。