### PR TITLE
Fix a bug that the position of the WordPress management bar shifts when the width is 600px or less

### DIFF
--- a/dist/css/style.css
+++ b/dist/css/style.css
@@ -389,6 +389,12 @@ a {
   outline: none;
 }
 
+@media screen and (max-width: 600px) {
+  #wpadminbar {
+    position: fixed !important;
+  }
+}
+
 .comments .comment-respond {
   overflow: hidden;
 }

--- a/src/sass/base/_base.scss
+++ b/src/sass/base/_base.scss
@@ -37,3 +37,11 @@ a {
 [data-whatinput="touch"] *:focus {
   outline: none;
 }
+
+//幅が600px以下の時、WordPressの管理バーの一がずれる不具合を修正
+@media screen and (max-width: 600px) {
+  #wpadminbar {
+    position: fixed !important;
+  }
+}
+  

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://github.com/kazukifuji/museum
 Author: kazukifuji
 Author URI: https://github.com/kazukifuji
 Description: このテーマの大きな特徴は2つあり、1つは、投稿一覧のレイアウトに「可変グリッドレイアウト」を採用し、投稿やサムネイルを美しく表示するよう設計されています。もう1つは投稿一覧のページングに「Ajax通信」を採用しているため、大量の投稿を高速かつスムーズに閲覧することが可能です。また、画像をより際立たせるように、このテーマは無彩色のみのシンプルなデザインになっております。何らかの商品や作品、大量の写真が使用されるwebサイトに適したテーマです。
-Version: 1.1.0
+Version: 1.1.1
 License: GNU General Public License v3
 License URI: LICENSE
 Tags: blog, photography, portfolio, grid-layout, two-columns, left-sidebar, custom-header, custom-menu, threaded-comments, featured-images


### PR DESCRIPTION
幅が600px以下の場合にWordPressの管理バーの位置がずれるバグを修正。