### PR TITLE
Fix a bug where tasks are called twice when 'gulp.watch' detects a file change

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,13 +9,9 @@ const gulp = require('gulp'),
 const tasks = {
   watch: function(done) {
     //sass, editorStyle
-    gulp.watch('./src/sass/**/*.scss')
-        .on( 'change', gulp.series(
-            gulp.parallel( tasks.sass, tasks.editorStyle )
-        ) );
+    gulp.watch('./src/sass/**/*.scss', { events: 'change' }, gulp.parallel( tasks.sass, tasks.editorStyle ) );
     //js
-    gulp.watch('./src/js/**/*.js')
-        .on( 'change', gulp.series( tasks.js ) );
+    gulp.watch('./src/js/**/*.js', { events: 'change' }, tasks.js );
 
     done();
   },


### PR DESCRIPTION
'gulp.watch'がファイルの変更を検出したときに、タスクが2回呼び出されるバグを修正。