### PR TITLE
Fix comment and search form styles

### DIFF
--- a/dist/css/style.css
+++ b/dist/css/style.css
@@ -389,6 +389,11 @@ a {
   outline: none;
 }
 
+[data-whatinput="keyboard"] input[type="text"],
+[data-whatinput="keyboard"] textarea {
+  outline: none;
+}
+
 @media screen and (max-width: 600px) {
   #wpadminbar {
     position: fixed !important;

--- a/dist/css/style.css
+++ b/dist/css/style.css
@@ -1872,14 +1872,11 @@ a {
   width: 100%;
 }
 
-.searchform__textbox:focus {
-  outline: none;
-}
-
 .searchform__submit {
   background: #EEE;
   border: none;
   cursor: pointer;
+  outline: none;
   padding: 0 20px;
   transition: background 0.2s linear;
 }
@@ -1896,15 +1893,11 @@ a {
   width: 10px;
 }
 
-.searchform__submit:focus {
-  outline: none;
-}
-
-.searchform__submit:hover {
+.searchform__submit:hover, .searchform__submit:focus {
   background: #333;
 }
 
-.searchform__submit:hover .searchform__submit-icon {
+.searchform__submit:hover .searchform__submit-icon, .searchform__submit:focus .searchform__submit-icon {
   stroke: white;
   transform: scale(1.9) rotate(360deg);
 }

--- a/functions.php
+++ b/functions.php
@@ -169,6 +169,7 @@ function museum_comment_form_default( $args ) {
   $args['fields']['author'] = '<p class="comment-form-author"><label for="author">名前</label> ' .
                                 '<input id="author" name="author" type="text" value="名無しさん" size="30" maxlength="30">' .
                               '</p>';
+  $args['fields']['cookies'] = '<p class="comment-form-cookies-consent"><input id="wp-comment-cookies-consent" name="wp-comment-cookies-consent" type="checkbox" value="yes"> <label for="wp-comment-cookies-consent">次回のコメントで使用するためブラウザーに自分の名前を保存する。</label></p>';
   $args['submit_button'] = '<button name="%1$s" type="submit" id="%2$s" class="%3$s" value="%4$s">%4$s</button>';
   return $args;
 }

--- a/src/sass/base/_base.scss
+++ b/src/sass/base/_base.scss
@@ -38,6 +38,11 @@ a {
   outline: none;
 }
 
+[data-whatinput="keyboard"] input[type="text"],
+[data-whatinput="keyboard"] textarea {
+  outline: none;
+}
+
 //幅が600px以下の時、WordPressの管理バーの一がずれる不具合を修正
 @media screen and (max-width: 600px) {
   #wpadminbar {

--- a/src/sass/blocks/_searchform.scss
+++ b/src/sass/blocks/_searchform.scss
@@ -13,16 +13,13 @@
     flex: 1 1 80%;
     padding: 10px;
     width: 100%;
-
-    &:focus {
-      outline: none;
-    }
   }
 
   &__submit {
     background: $gray;
     border: none;
     cursor: pointer;
+    outline: none;
     padding: 0 20px;
     transition: background 0.2s linear;
 
@@ -38,11 +35,7 @@
       width: 10px;
     }
 
-    &:focus {
-      outline: none;
-    }
-
-    &:hover {
+    &:hover, &:focus {
       background: $black;
 
       .searchform__submit-icon {


### PR DESCRIPTION
コメントフォームと検索フォームのスタイルを修正。

- 'input[type="text"]'と'textarea'要素のキーボード操作によるフォーカスアウトラインを非表示。
- 検索フォーム内の検索ボタンのフォーカススタイルを変更。
- Cookie保存同意チェックボックスの文章を変更。