### PR TITLE
Allow uploads of other files using the WordPress custom header feature

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -61,7 +61,7 @@ function museum_theme_supports() {
     'header-text'        => false,
     'default-text-color' => 'FFF',
     'video'              => false,
-    'uploads'            => false,
+    'uploads'            => true,
     'random-default'     => false,
   ] );
 }


### PR DESCRIPTION
ライブラリ上の画像をリサイズしてカスタムヘッダー画像に使用することができなかったので、
WordPressのカスタムヘッダー機能を使用した、他のファイルのアップロードを許可し、リサイズ後の画像を使用できるようにした。