### PR TITLE
Fix a mistake in webpack settings

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -35,7 +35,6 @@ module.exports = {
       
       {
         test: /\.css$/,
-        exclude: /node_modules/,
         use: [
           "style-loader",
           {


### PR DESCRIPTION
webpackの設定の間違いを修正。

現在の設定だと、npmパッケージ内のcssファイルがインポートできないため、webpack.config.jsのcssファイルスコープにnode_modulesディレクトリを含める。
