### PR TITLE
Fix some bugs

### DIFF
--- a/src/js/features/postList.js
+++ b/src/js/features/postList.js
@@ -95,7 +95,7 @@ export default {
       this.status.element.style.display = 'block';
       document.querySelector( this.status.selector + ' > .infinite-scroll-request' ).style.display = 'none';
       document.querySelector( this.status.selector + ' > .infinite-scroll-error' ).style.display = 'none';
-      this.navigation.element.style.display = 'none';
+      if ( this.navigation.element ) this.navigation.element.style.display = 'none';
     }
   }, 
 }

--- a/src/js/features/postList.js
+++ b/src/js/features/postList.js
@@ -9,7 +9,6 @@ export default {
   init: function() {
     //投稿リスト
     this.element = document.getElementById('postList');
-    console.dir(this.element);
     if ( !this.element ) return;
 
     //投稿コンテナー

--- a/src/sass/blocks/_menu.scss
+++ b/src/sass/blocks/_menu.scss
@@ -12,7 +12,7 @@
     color: inherit;
   }
 
-  &, .sub-menu {
+  ul {
     list-style: none;
     margin: 0;
     padding-left: 14px;
@@ -27,4 +27,10 @@
       }
     }
   }
+}
+
+ul.menu {
+  list-style: none;
+  margin: 0;
+  padding-left: 14px;
 }


### PR DESCRIPTION
いくつかのバグを修正。

### 詳細

- 投稿リストモジュールファイルに残っていた、console.dirコードを削除。

- 投稿リストのページネーション要素が存在しない場合、エラーが発生するバグを修正。

- WordPressのカスタムナビゲーションメニューが設定されていない時、リストスタイルが
表示されるバグを修正。