### PR TITLE
Fix 'main' block element styles

### DIFF
--- a/src/sass/blocks/_main.scss
+++ b/src/sass/blocks/_main.scss
@@ -1,5 +1,6 @@
 .main{
   overflow: hidden;
+  padding-bottom: 20px;
 
   &__heading {
     &-1 {

--- a/src/sass/blocks/_main.scss
+++ b/src/sass/blocks/_main.scss
@@ -1,5 +1,5 @@
 .main{
-  overflow: relative;
+  overflow: hidden;
 
   &__heading {
     &-1 {


### PR DESCRIPTION
'main'ブロック要素のスタイルを修正。

- 'overflow: relative;'の打ち間違いを'overflow: hidden'に修正。

- 'padding-bottom'のスタイルを追加。