### PR TITLE
Add WordPress default widget styles and hide unused widgets

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -14,6 +14,7 @@
 
 ＊ウィジェット関連
 -ウィジェットを登録
+-使用しないデフォルトウィジェットを非表示
 
 ＊ナビゲーションメニュー関連
 -カスタムナビゲーションメニューを登録
@@ -127,6 +128,19 @@ function museum_widgets() {
     'before_title' => '<h4 class="widgettitle">',
     'after_title' => '</h4>',
   ]);
+}
+
+
+// 使用しないデフォルトウィジェットを非表示
+add_action( 'widgets_init', 'museum_unregister_default_widgets' );
+function museum_unregister_default_widgets() {
+  unregister_widget('WP_Widget_Calendar');    //カレンダー 
+  unregister_widget('WP_Widget_RSS');         //RSS
+  unregister_widget('WP_Nav_Menu_Widget');    //ナビゲーションメニュー
+  unregister_widget('WP_Widget_Media_Video');   //動画
+  unregister_widget('WP_Widget_Media_Audio');   //音声
+  unregister_widget('WP_Widget_Media_Gallery'); //ギャラリー
+  unregister_widget('WP_Widget_Custom_HTML');   //カスタムHTML
 }
 
 

--- a/src/sass/blocks/_widget.scss
+++ b/src/sass/blocks/_widget.scss
@@ -2,9 +2,9 @@
   font-size: 1.3rem;
 
   .widgettitle {
-    font-size: 1.4rem;
+    font-size: 1.5rem;
     font-weight: bold;
-    margin: 0 0 5px 0;
+    margin: 0 0 1em 0;
   }
   
   .screen-reader-text {

--- a/src/sass/blocks/_widget.scss
+++ b/src/sass/blocks/_widget.scss
@@ -1,6 +1,31 @@
 .widget {
   font-size: 1.3rem;
 
+  //固定ページ
+  &_pages {
+    a { color: inherit }
+
+    ul {
+      list-style: none;
+      margin: 0;
+      padding: 0 0 0 10px;
+
+      &.children {
+        li:last-child {
+          padding-bottom: 0;
+        }
+      }
+
+      li {
+        padding: 8px 0;
+        
+        &:not(:last-child) {
+          border-bottom: 1px solid $gray;
+        }
+      }
+    }
+  }
+  
   .widgettitle {
     font-size: 1.5rem;
     font-weight: bold;

--- a/src/sass/blocks/_widget.scss
+++ b/src/sass/blocks/_widget.scss
@@ -2,9 +2,9 @@
   font-size: 1.3rem;
 
   //アーカイブ、カテゴリー、メタ情報
-  //最近の投稿、固定ページ
+  //最近のコメント、最近の投稿、固定ページ
   &_archive, &_categories, &_meta,
-  &_recent_entries, &_pages {
+  &_recent_comments, &_recent_entries, &_pages {
     a { color: inherit }
 
     ul {
@@ -26,6 +26,11 @@
         }
       }
     }
+  }
+
+  //最近のコメント
+  &_recent_comments {
+    a { text-decoration: underline }
   }
 
   //タグクラウド

--- a/src/sass/blocks/_widget.scss
+++ b/src/sass/blocks/_widget.scss
@@ -28,6 +28,11 @@
     }
   }
 
+  //タグクラウド
+  &_tag_cloud {
+    a { color: inherit }
+  }
+
   .widgettitle {
     font-size: 1.5rem;
     font-weight: bold;

--- a/src/sass/blocks/_widget.scss
+++ b/src/sass/blocks/_widget.scss
@@ -1,30 +1,6 @@
 .widget {
   font-size: 1.3rem;
 
-  a {
-    color: inherit;
-  }
-
-  ul {
-    list-style: none;
-    margin: 0;
-    padding: 0 0 0 10px;
-
-    &.children {
-      li:last-child {
-        padding-bottom: 0;
-      }
-    }
-
-    li {
-      padding: 8px 0;
-      
-      &:not(:last-child) {
-        border-bottom: 1px solid $gray;
-      }
-    }
-  }
-
   .widgettitle {
     font-size: 1.4rem;
     font-weight: bold;

--- a/src/sass/blocks/_widget.scss
+++ b/src/sass/blocks/_widget.scss
@@ -1,8 +1,8 @@
 .widget {
   font-size: 1.3rem;
 
-  //固定ページ
-  &_pages {
+  //最近の投稿、固定ページ
+  &_recent_entries, &_pages {
     a { color: inherit }
 
     ul {

--- a/src/sass/blocks/_widget.scss
+++ b/src/sass/blocks/_widget.scss
@@ -1,8 +1,8 @@
 .widget {
   font-size: 1.3rem;
 
-  //最近の投稿、固定ページ
-  &_recent_entries, &_pages {
+  //アーカイブ、最近の投稿、固定ページ
+  &_archive, &_recent_entries, &_pages {
     a { color: inherit }
 
     ul {
@@ -25,7 +25,7 @@
       }
     }
   }
-  
+
   .widgettitle {
     font-size: 1.5rem;
     font-weight: bold;

--- a/src/sass/blocks/_widget.scss
+++ b/src/sass/blocks/_widget.scss
@@ -1,8 +1,10 @@
 .widget {
   font-size: 1.3rem;
 
-  //アーカイブ、最近の投稿、固定ページ
-  &_archive, &_recent_entries, &_pages {
+  //アーカイブ、カテゴリー
+  //最近の投稿、固定ページ
+  &_archive, &_categories,
+  &_recent_entries, &_pages {
     a { color: inherit }
 
     ul {

--- a/src/sass/blocks/_widget.scss
+++ b/src/sass/blocks/_widget.scss
@@ -1,9 +1,9 @@
 .widget {
   font-size: 1.3rem;
 
-  //アーカイブ、カテゴリー
+  //アーカイブ、カテゴリー、メタ情報
   //最近の投稿、固定ページ
-  &_archive, &_categories,
+  &_archive, &_categories, &_meta,
   &_recent_entries, &_pages {
     a { color: inherit }
 


### PR DESCRIPTION
WordPressのデフォルトウィジェットのスタイルを追加し、未使用のウィジェットを非表示にする。