### PR TITLE
Fix a bug where the focus outline was displayed on the 'input[type="email"]' element

### DIFF
--- a/src/sass/base/_base.scss
+++ b/src/sass/base/_base.scss
@@ -38,11 +38,6 @@ a {
   outline: none;
 }
 
-[data-whatinput="keyboard"] input[type="text"],
-[data-whatinput="keyboard"] textarea {
-  outline: none;
-}
-
 //幅が600px以下の時、WordPressの管理バーの一がずれる不具合を修正
 @media screen and (max-width: 600px) {
   #wpadminbar {

--- a/src/sass/mixin/_text-area.scss
+++ b/src/sass/mixin/_text-area.scss
@@ -4,6 +4,7 @@
   background: #F8F8F8;
   border: none;
   line-height: inherit;
+  outline: none;
   padding: 12px;
   resize: vertical;
   width: 100%;

--- a/src/sass/mixin/_text-field.scss
+++ b/src/sass/mixin/_text-field.scss
@@ -4,6 +4,7 @@
   background: #F8F8F8;
   border: none;
   line-height: inherit;
+  outline: none;
   padding: 12px;
   width: 100%;
 }


### PR DESCRIPTION
'input [type = "email"]'要素にフォーカスアウトラインが表示されるバグを修正。

詳細 #107 